### PR TITLE
Improve types

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,15 +1,10 @@
 import * as helpers from './helpers';
-import { FormatFn } from './types';
+import { Formatter } from './types';
 export { helpers };
 export declare const templateDefaults: {
     branch: string;
     commit: string;
     command: string;
 };
-interface Parser {
-    branch: FormatFn;
-    command: FormatFn;
-    commit: FormatFn;
-}
-declare const _default: (templates?: {}, prettify?: boolean) => Parser;
+declare const _default: (templates?: {}, prettify?: boolean) => Formatter;
 export default _default;

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -6,6 +6,11 @@ export declare type Templates = {
     commit?: string;
     command?: string;
 };
-export declare type FormatterName = 'branch' | 'commit' | 'command';
-export declare type StringMappingFn = (input: string) => string;
 export declare type FormatFn = (ticket: Ticket) => string;
+export interface Formatter {
+    branch: FormatFn;
+    command: FormatFn;
+    commit: FormatFn;
+}
+export declare type FormatterName = keyof Formatter;
+export declare type StringMappingFn = (input: string) => string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as helpers from './helpers';
 import pprint from './pretty-print';
 import compile from './template';
-import { FormatFn, FormatterName, Templates, Ticket } from './types';
+import { FormatFn, Formatter, FormatterName, Templates, Ticket } from './types';
 
 export { helpers };
 
@@ -23,13 +23,7 @@ const renderer = (templates: Templates, name: FormatterName): FormatFn => {
   return (ticket: Ticket) => render({ ...fallbacks, ...ticket }).trim();
 };
 
-interface Parser {
-  branch: FormatFn;
-  command: FormatFn;
-  commit: FormatFn;
-}
-
-export default (templates = {}, prettify = true): Parser => {
+export default (templates = {}, prettify = true): Formatter => {
   const branch = renderer(templates, 'branch');
 
   const commitFn = renderer(templates, 'commit');

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,11 @@ export type Templates = {
   commit?: string;
   command?: string;
 };
-export type FormatterName = 'branch' | 'commit' | 'command';
-export type StringMappingFn = (input: string) => string;
 export type FormatFn = (ticket: Ticket) => string;
+export interface Formatter {
+  branch: FormatFn;
+  command: FormatFn;
+  commit: FormatFn;
+}
+export type FormatterName = keyof Formatter;
+export type StringMappingFn = (input: string) => string;


### PR DESCRIPTION
1. Rename "Parser" type to "Formatter"
2. Extract "Formatter" type and put it next to other types
3. Export "Formatter" type
4. Derive "FormatterName" type from "Formatter" keys
